### PR TITLE
Remove unnecessary asserts and add new one

### DIFF
--- a/contracting/contracts/submission.s.py
+++ b/contracting/contracts/submission.s.py
@@ -1,11 +1,19 @@
 @__export('submission')
-def submit_contract(name: str, code: str, owner: Any = None, constructor_args: dict = {}):
-    assert not name.isdigit() and all(c.isalnum() or c == '_' for c in name), 'Invalid contract name!'
-    # assert name.startswith('con_'), 'Contract must start with con!'
-    assert ctx.caller == ctx.signer, 'Cannot be called from a smart contract!'
-    assert name.islower(), 'Name must be lowercase!'
+def submit_contract(name: str, code: str, owner: Any=None, constructor_args: dict={}):
+    if ctx.caller != 'sys':
+        assert name.startswith('con_'), 'Contract must start with con_!'
 
-    __Contract().submit(name=name, code=code, owner=owner, constructor_args=constructor_args, developer=ctx.caller)
+    assert ctx.caller == ctx.signer, 'Contract cannot be called from another contract!'
+    assert len(name) <= 64, 'Contract name length exceeds 64 characters!'
+    assert name.islower(), 'Contract name must be lowercase!'
+
+    __Contract().submit(
+        name=name,
+        code=code,
+        owner=owner,
+        constructor_args=constructor_args,
+        developer=ctx.caller
+    )
 
 
 @__export('submission')
@@ -13,6 +21,8 @@ def change_developer(contract: str, new_developer: str):
     d = __Contract()._driver.get_var(contract=contract, variable='__developer__')
     assert ctx.caller == d, 'Sender is not current developer!'
 
-    __Contract()._driver.set_var(contract=contract,
-                                 variable='__developer__',
-                                 value=new_developer)
+    __Contract()._driver.set_var(
+        contract=contract,
+        variable='__developer__',
+        value=new_developer
+    )


### PR DESCRIPTION
Since we have the check for `startswith("con_")` we don't need any other check for the contract name. But I added another check for the contract lenght - which is now fixed at max 64 characters.