### PR TITLE
as_dict function for hashes

### DIFF
--- a/contracting/storage/driver.py
+++ b/contracting/storage/driver.py
@@ -254,7 +254,7 @@ class Driver:
     def make_key(self, contract, variable, args=[]):
         contract_variable = DELIMITER.join((contract, variable))
         if args:
-            return ":".join((contract_variable, *[str(arg) for arg in args]))
+            return HASH_DEPTH_DELIMITER.join((contract_variable, *[str(arg) for arg in args]))
         return contract_variable
 
     def get_var(self, contract, variable, arguments=[], mark=True):

--- a/contracting/storage/driver.py
+++ b/contracting/storage/driver.py
@@ -24,6 +24,7 @@ HASH_EXT = ".x"
 
 STORAGE_HOME = Path().home().joinpath(".cometbft/xian")
 DELIMITER = "."
+HASH_DEPTH_DELIMITER = ":"
 
 CODE_KEY = "__code__"
 TYPE_KEY = "__type__"
@@ -235,6 +236,20 @@ class Driver:
     def values(self, prefix=""):
         l = list(self.items(prefix).values())
         return list(self.items(prefix).values())
+
+    def key_values(self, prefix="", max_depth=1, max_length=10000):
+        if max_length > 1000000:
+            raise ValueError("Max length is too high")
+        result = dict()
+        keys = self.keys(prefix=prefix)
+        for key in keys:
+            depth = key.count(HASH_DEPTH_DELIMITER)
+            if depth > max_depth:
+                continue
+            if len(result) >= max_length:
+                break
+            result[key.replace(prefix, "")] = self.get(key)
+        return result
 
     def make_key(self, contract, variable, args=[]):
         contract_variable = DELIMITER.join((contract, variable))

--- a/contracting/storage/driver.py
+++ b/contracting/storage/driver.py
@@ -237,17 +237,13 @@ class Driver:
         l = list(self.items(prefix).values())
         return list(self.items(prefix).values())
 
-    def key_values(self, prefix="", max_depth=1, max_length=10000):
-        if max_length > 1000000:
-            raise ValueError("Max length is too high")
+    def key_values(self, prefix="", max_depth=1):
         result = dict()
         keys = self.keys(prefix=prefix)
         for key in keys:
             depth = key.count(HASH_DEPTH_DELIMITER)
             if depth > max_depth:
                 continue
-            if len(result) >= max_length:
-                break
             result[key.replace(prefix, "")] = self.get(key)
         return result
 

--- a/contracting/storage/orm.py
+++ b/contracting/storage/orm.py
@@ -95,7 +95,7 @@ class Hash(Datum):
 
     def as_dict(self, *args):
         prefix = self._prefix_for_args(args)
-        return self._driver.key_values(prefix=prefix, max_depth=1, max_length=10000)
+        return self._driver.key_values(prefix=prefix, max_depth=1)
 
     def _items(self, *args):
         prefix = self._prefix_for_args(args)

--- a/contracting/storage/orm.py
+++ b/contracting/storage/orm.py
@@ -93,6 +93,10 @@ class Hash(Datum):
         prefix = self._prefix_for_args(args)
         return self._driver.values(prefix=prefix)
 
+    def as_dict(self, *args):
+        prefix = self._prefix_for_args(args)
+        return self._driver.key_values(prefix=prefix, max_depth=1, max_length=10000)
+
     def _items(self, *args):
         prefix = self._prefix_for_args(args)
         return self._driver.items(prefix=prefix)


### PR DESCRIPTION
This is the example contract:


```
balances = Hash(default_value=0)

@construct
def seed(vk: str):
    balances['boi'] = 111_111_111
    balances['bob'] = 100_000
    balances['bob', 'down'] = 100_000
    
@export
def holders():
    return balances.as_dict()

```
    
When calling holders()

It will return a dict copy
`{'boi': 111111111, 'bob': 100000}`

which then can be looped through. for example for airdrops
